### PR TITLE
Add block number getter to VersionedSignedBuilderBid

### DIFF
--- a/spec/versionedsignedbuilderbid.go
+++ b/spec/versionedsignedbuilderbid.go
@@ -99,6 +99,39 @@ func (v *VersionedSignedBuilderBid) Value() (*uint256.Int, error) {
 	}
 }
 
+// BlockNumber returns the block number of the bid.
+func (v *VersionedSignedBuilderBid) BlockNumber() (uint64, error) {
+	if v == nil {
+		return 0, errors.New("nil struct")
+	}
+	switch v.Version {
+	case consensusspec.DataVersionBellatrix:
+		if v.Bellatrix == nil {
+			return 0, errors.New("no data")
+		}
+		if v.Bellatrix.Message == nil {
+			return 0, errors.New("no data message")
+		}
+		if v.Bellatrix.Message.Header == nil {
+			return 0, errors.New("no data message header")
+		}
+		return v.Bellatrix.Message.Header.BlockNumber, nil
+	case consensusspec.DataVersionCapella:
+		if v.Capella == nil {
+			return 0, errors.New("no data")
+		}
+		if v.Capella.Message == nil {
+			return 0, errors.New("no data message")
+		}
+		if v.Capella.Message.Header == nil {
+			return 0, errors.New("no data message header")
+		}
+		return v.Capella.Message.Header.BlockNumber, nil
+	default:
+		return 0, errors.New("unsupported version")
+	}
+}
+
 // BlockHash returns the block hash of the bid.
 func (v *VersionedSignedBuilderBid) BlockHash() (phase0.Hash32, error) {
 	if v == nil {

--- a/spec/versionedsignedbuilderbid_test.go
+++ b/spec/versionedsignedbuilderbid_test.go
@@ -249,6 +249,117 @@ func TestVersionedSignedBuilderBidValue(t *testing.T) {
 	}
 }
 
+func TestVersionedSignedBuilderBidBlockNumber(t *testing.T) {
+	tests := []struct {
+		name string
+		bid  *spec.VersionedSignedBuilderBid
+		res  uint64
+		err  string
+	}{
+		{
+			name: "Empty",
+			err:  "nil struct",
+		},
+		{
+			name: "UnsupportedVersion",
+			bid: &spec.VersionedSignedBuilderBid{
+				Version: consensusspec.DataVersionAltair,
+			},
+			err: "unsupported version",
+		},
+		{
+			name: "BellatrixNoData",
+			bid: &spec.VersionedSignedBuilderBid{
+				Version: consensusspec.DataVersionBellatrix,
+			},
+			err: "no data",
+		},
+		{
+			name: "BellatrixNoDataMessage",
+			bid: &spec.VersionedSignedBuilderBid{
+				Version:   consensusspec.DataVersionBellatrix,
+				Bellatrix: &bellatrix.SignedBuilderBid{},
+			},
+			err: "no data message",
+		},
+		{
+			name: "BellatrixNoDataMessageHeader",
+			bid: &spec.VersionedSignedBuilderBid{
+				Version: consensusspec.DataVersionBellatrix,
+				Bellatrix: &bellatrix.SignedBuilderBid{
+					Message: &bellatrix.BuilderBid{},
+				},
+			},
+			err: "no data message header",
+		},
+		{
+			name: "BellatrixGood",
+			bid: &spec.VersionedSignedBuilderBid{
+				Version: consensusspec.DataVersionBellatrix,
+				Bellatrix: &bellatrix.SignedBuilderBid{
+					Message: &bellatrix.BuilderBid{
+						Header: &consensusbellatrix.ExecutionPayloadHeader{
+							BlockNumber: 123,
+						},
+					},
+				},
+			},
+			res: 123,
+		},
+		{
+			name: "CapellaNoData",
+			bid: &spec.VersionedSignedBuilderBid{
+				Version: consensusspec.DataVersionCapella,
+			},
+			err: "no data",
+		},
+		{
+			name: "CapellaNoDataMessage",
+			bid: &spec.VersionedSignedBuilderBid{
+				Version: consensusspec.DataVersionCapella,
+				Capella: &capella.SignedBuilderBid{},
+			},
+			err: "no data message",
+		},
+		{
+			name: "CapellaNoDataMessageHeader",
+			bid: &spec.VersionedSignedBuilderBid{
+				Version: consensusspec.DataVersionCapella,
+				Capella: &capella.SignedBuilderBid{
+					Message: &capella.BuilderBid{},
+				},
+			},
+			err: "no data message header",
+		},
+		{
+			name: "CapellaGood",
+			bid: &spec.VersionedSignedBuilderBid{
+				Version: consensusspec.DataVersionCapella,
+				Capella: &capella.SignedBuilderBid{
+					Message: &capella.BuilderBid{
+						Header: &consensuscapella.ExecutionPayloadHeader{
+							BlockNumber: 123,
+						},
+					},
+				},
+			},
+			res: 123,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			res, err := test.bid.BlockNumber()
+			if test.err != "" {
+				require.EqualError(t, err, test.err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, test.res, res)
+			}
+		})
+	}
+}
+
 func TestVersionedSignedBuilderBidParentHash(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
Add `BlockNumber()` as it is a field that is used in mev-boost