### PR TITLE
Add transactions field to versioned paylod

### DIFF
--- a/api/versionedexecutionpayload.go
+++ b/api/versionedexecutionpayload.go
@@ -69,7 +69,7 @@ func (v *VersionedExecutionPayload) BlockHash() (phase0.Hash32, error) {
 	}
 }
 
-// Transactions returns the transactions in the execution payload
+// Transactions returns the transactions in the execution payload.
 func (v *VersionedExecutionPayload) Transactions() ([]bellatrix.Transaction, error) {
 	if v == nil {
 		return nil, errors.New("nil struct")

--- a/api/versionedexecutionpayload.go
+++ b/api/versionedexecutionpayload.go
@@ -68,3 +68,29 @@ func (v *VersionedExecutionPayload) BlockHash() (phase0.Hash32, error) {
 		return phase0.Hash32{}, errors.New("unsupported version")
 	}
 }
+
+// Transactions returns the transactions in the execution payload
+func (v *VersionedExecutionPayload) Transactions() ([]bellatrix.Transaction, error) {
+	if v == nil {
+		return nil, errors.New("nil struct")
+	}
+	switch v.Version {
+	case consensusspec.DataVersionBellatrix:
+		if v.Bellatrix == nil {
+			return nil, errors.New("no data")
+		}
+		return v.Bellatrix.Transactions, nil
+	case consensusspec.DataVersionCapella:
+		if v.Capella == nil {
+			return nil, errors.New("no data")
+		}
+		return v.Capella.Transactions, nil
+	case consensusspec.DataVersionDeneb:
+		if v.Deneb == nil {
+			return nil, errors.New("no data")
+		}
+		return v.Deneb.Transactions, nil
+	default:
+		return nil, errors.New("unsupported version")
+	}
+}

--- a/api/versionedexecutionpayload_test.go
+++ b/api/versionedexecutionpayload_test.go
@@ -158,3 +158,82 @@ func TestVersionedExecutionPayloadBlockHash(t *testing.T) {
 		})
 	}
 }
+
+func TestVersionedExecutionPayloadTransactions(t *testing.T) {
+	tests := []struct {
+		name string
+		bid  *api.VersionedExecutionPayload
+		res  []bellatrix.Transaction
+		err  string
+	}{
+		{
+			name: "Empty",
+			err:  "nil struct",
+		},
+		{
+			name: "UnsupportedVersion",
+			bid: &api.VersionedExecutionPayload{
+				Version: consensusspec.DataVersionAltair,
+			},
+			err: "unsupported version",
+		},
+		{
+			name: "BellatrixNoData",
+			bid: &api.VersionedExecutionPayload{
+				Version: consensusspec.DataVersionBellatrix,
+			},
+			err: "no data",
+		},
+		{
+			name: "BellatrixGood",
+			bid: &api.VersionedExecutionPayload{
+				Version: consensusspec.DataVersionBellatrix,
+				Bellatrix: &bellatrix.ExecutionPayload{
+					Transactions: []bellatrix.Transaction{
+						{0x00},
+						{0x01},
+					},
+				},
+			},
+			res: []bellatrix.Transaction{
+				{0x00},
+				{0x01},
+			},
+		},
+		{
+			name: "CapellaNoData",
+			bid: &api.VersionedExecutionPayload{
+				Version: consensusspec.DataVersionCapella,
+			},
+			err: "no data",
+		},
+		{
+			name: "CapellaGood",
+			bid: &api.VersionedExecutionPayload{
+				Version: consensusspec.DataVersionCapella,
+				Capella: &capella.ExecutionPayload{
+					Transactions: []bellatrix.Transaction{
+						{0x00},
+						{0x01},
+					},
+				},
+			},
+			res: []bellatrix.Transaction{
+				{0x00},
+				{0x01},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			res, err := test.bid.Transactions()
+			if test.err != "" {
+				require.EqualError(t, err, test.err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, test.res, res)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Used in mev-boost-relay for logging number of transactions in the payload