### PR TITLE
Unpack ExecutionRequests in SubmitBlockRequest

### DIFF
--- a/api/electra/submitblockrequest_json.go
+++ b/api/electra/submitblockrequest_json.go
@@ -85,5 +85,10 @@ func (s *SubmitBlockRequest) unpack(data *submitBlockRequestJSON) error {
 	}
 	s.BlobsBundle = data.BlobsBundle
 
+	if data.ExecutionRequests == nil {
+		return errors.New("execution requests missing")
+	}
+	s.ExecutionRequests = data.ExecutionRequests
+
 	return nil
 }


### PR DESCRIPTION
I forgot to include `ExecutionRequests` in `SubmitBlockRequest.unpack()`...