### PR TITLE
Fix mistake in Electra bid value SSZ unmarshaling

### DIFF
--- a/api/electra/builderbid_ssz.go
+++ b/api/electra/builderbid_ssz.go
@@ -98,7 +98,7 @@ func (b *BuilderBid) UnmarshalSSZ(buf []byte) error {
 	// Field (3) 'Value'
 	value := make([]byte, 32)
 	for i := 0; i < 32; i++ {
-		value[i] = buf[44-i]
+		value[i] = buf[43-i]
 	}
 	if b.Value == nil {
 		b.Value = new(uint256.Int)


### PR DESCRIPTION
While testing the builder workflow with SSZ, @pawanjay176 noticed that SSZ-unmarshaled `BuilderBid` values in Electra did not match what the builder provided. But this was only an Electra issue, not Deneb. When given the value is `uint256::max` there is an incorrect highest byte.

```
>>> hex(115792089237316195423570985008687907853269984665640564039457584007913129639935)
'0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
>>> hex(75083932864822220469971810591571065248604755681626303244335777130131170000895)
'0xa5ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
```

After some investigation, we realized that the `UnmarshalSSZ` function for `BuilderBid` had a bug (which was actually my fault 🤦). When hand-fixing the `uint256.Int` decoding, I used the wrong constant.

For reference, compare the Deneb & Electra versions of this code.
 
https://github.com/attestantio/go-builder-client/blob/11f33217a1adddc73935e0d81805c4a511282068/api/deneb/builderbid_ssz.go#L79-L95

https://github.com/attestantio/go-builder-client/blob/11f33217a1adddc73935e0d81805c4a511282068/api/electra/builderbid_ssz.go#L88-L109

Note that in Deneb the constant is 39 and in Electra it's 44. This is a 5 byte difference, not a 4 byte difference. 