### PR TITLE
fix: pin GitHub Actions to SHA for supply chain security

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,13 +14,13 @@ jobs:
     name: lint
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           cache: false
           go-version: "1.25"
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8
         with:
           version: "latest"
           args: "--timeout=60m"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,11 +8,11 @@ jobs:
   test:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           cache: false
           go-version: "1.25.2"
-      - uses: actions/checkout@v4
-      - uses: n8maninger/action-golang-test@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: n8maninger/action-golang-test@aa292dc81b16d34406a9551e629e0cdca00d9418 # v2
         with:
           args: "-race;-timeout=30m"


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions to their full commit SHA instead of mutable tags to prevent supply chain attacks via tag manipulation
- Original version tags preserved as inline comments for readability

### Actions pinned

| Action | Version |
|--------|---------|
| `actions/checkout` | v4 |
| `actions/setup-go` | v5 |
| `golangci/golangci-lint-action` | v8 |
| `n8maninger/action-golang-test` | v2 |

## Test plan

- [ ] Verify CI workflows pass with SHA-pinned actions
- [ ] Confirm no functional changes to workflow behavior