### PR TITLE
chore: add Renovate config for GitHub Actions updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "enabledManagers": ["github-actions"],
+  "packageRules": [{
+    "matchManagers": ["github-actions"],
+    "matchDepTypes": ["github-actions"],
+    "matchFileNames": [".github/workflows/**"],
+    "schedule": ["every weekend"],
+    "labels": ["renovate/github-actions"],
+    "groupName": "GitHub Actions updates"
+  }]
+}


### PR DESCRIPTION
## Summary
- Add Renovate bot configuration to automatically track and update GitHub Actions versions
- Configured to run on weekends only, grouping all GHA updates into a single PR
- Scoped to GitHub Actions manager only (no other dependency scanning)

## Test plan
- [ ] Verify Renovate bot picks up the config and creates update PRs